### PR TITLE
Add variable var.lock_failure_alarm_treat_missing_data to pass into t…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -81,5 +81,6 @@ resource "aws_cloudwatch_metric_alarm" "scheduled_task_failure_to_obtain_lock_al
     threshold                 = "${var.num_lock_failure_alarm_threshold}"
     alarm_description         = "Fails when the task ${var.task_name} on ${var.env_short_name} env fails to obtain a lock ${var.num_lock_failure_alarm_threshold} times in ${var.num_minutes_lock_failure_alarm_threshold} minutes"
     alarm_actions             = ["${var.alarm_action_arns}"]
+    treat_missing_data        = "${var.lock_failure_alarm_treat_missing_data}"
     insufficient_data_actions = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -54,3 +54,8 @@ variable "num_minutes_lock_failure_alarm_threshold" {
     description = "The number of minutes to evaluate the num_lock_failure_alarm_threshold for alerting"
     default = "1"
 }
+
+variable "lock_failure_alarm_treat_missing_data" {
+    description = "Sets how the 'failure to obtain lock alarm is to handle missing data points"
+    default = "missing"
+}


### PR DESCRIPTION
…he failure to obtain lock alarm

The default is `missing`, which shows our alarms as "Insufficient data" if the scheduled task doesn't run often (daily jobs, etc). This will allow us to override to `ignore`, which maintains the state of the alarm as it was